### PR TITLE
FLIP-136 [refactor] HomeScreen 리팩토링 & PullToRefresh 작업 중

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -2,10 +2,16 @@
 <project version="4">
   <component name="deploymentTargetDropDown">
     <value>
-      <entry key="SampleMainNavigationPreview">
+      <entry key="FlipPullRefreshLazyColumn2Preview">
         <State />
       </entry>
-      <entry key="SampleNavigationPreview">
+      <entry key="FlipPullRefreshLazyColumnPreview">
+        <State />
+      </entry>
+      <entry key="PullSample">
+        <State />
+      </entry>
+      <entry key="PullToRefreshAnimationPreview">
         <State />
       </entry>
       <entry key="app">

--- a/domain/src/main/java/com/team/domain/model/category/fixedCategories.kt
+++ b/domain/src/main/java/com/team/domain/model/category/fixedCategories.kt
@@ -1,0 +1,13 @@
+package com.team.domain.model.category
+
+/**
+ * 고정 카테고리
+ * 1. id(100): 전체
+ * 2. id(101): 팔로잉
+ * 3. id(102): 인기 플립
+ */
+val fixedCategories = listOf(
+    Category(100, "전체"),
+    Category(101, "팔로잉"),
+    Category(102, "인기 플립"),
+)

--- a/domain/src/main/java/com/team/domain/usecase/interestcategory/GetFilteredMyCategoriesUseCase.kt
+++ b/domain/src/main/java/com/team/domain/usecase/interestcategory/GetFilteredMyCategoriesUseCase.kt
@@ -1,0 +1,30 @@
+package com.team.domain.usecase.interestcategory
+
+import com.team.domain.model.category.Category
+import com.team.domain.model.category.fixedCategories
+import com.team.domain.usecase.category.GetCategoriesUseCase
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import javax.inject.Inject
+
+class GetFilteredMyCategoriesUseCase @Inject constructor(
+    private val getCategoriesUseCase: GetCategoriesUseCase,
+    private val getMyCategoriesUseCase: GetMyCategoriesUseCase,
+) {
+
+    /**
+     * 모든 카테고리를 가져 오고 나의 관심 카테고리로 필터링 한다.
+     *
+     * 결과: 고정 카테고리 + 나의 관심 카테고리
+     *
+     * 주의 사항: 오류 발생 시 빈 리스트 반환, 오류 처리 필요 시 처리 요망
+     */
+    operator fun invoke(): Flow<List<Category>> =
+        combine(getCategoriesUseCase(), getMyCategoriesUseCase()) { categories, myCategoryIds ->
+            myCategoryIds?.let { myCateIds ->
+                fixedCategories + myCateIds.mapNotNull { id ->
+                    categories.find { it.id == id }
+                }
+            } ?: fixedCategories
+        }
+}

--- a/domain/src/main/java/com/team/domain/usecase/interestcategory/UpdateMyCategoriesUseCase.kt
+++ b/domain/src/main/java/com/team/domain/usecase/interestcategory/UpdateMyCategoriesUseCase.kt
@@ -11,6 +11,11 @@ class UpdateMyCategoriesUseCase @Inject constructor(
     private val userRepository: UserRepository
 ) {
 
+    /**
+     * 나의 관심 카테고리 수정
+     *
+     * @param myCategories 수정된 카테고리 리스트
+     */
     operator fun invoke(myCategories: List<Category>): Flow<Result<Boolean, ErrorType>> =
         userRepository.updateMyCategories(myCategories.map { it.id })
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -53,6 +53,7 @@ androidx-compose-ui-graphics = { group = "androidx.compose.ui", name = "ui-graph
 androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4"}
 androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest"}
 androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling"}
+androidx-compose-ui-util = { group = "androidx.compose.ui", name = "ui-util"}
 androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview"}
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidxCore" }
 androidx-core-splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref = "androidxCoreSplashscreen" }

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -100,6 +100,7 @@ dependencies {
     implementation(libs.androidx.compose.ui)
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.compose.ui.util)
 
     // Coil
     implementation(libs.coil.compose)

--- a/presentation/src/main/java/com/team/presentation/common/pullrefresh/FlipPullRefreshLazyColumn.kt
+++ b/presentation/src/main/java/com/team/presentation/common/pullrefresh/FlipPullRefreshLazyColumn.kt
@@ -1,0 +1,261 @@
+package com.team.presentation.common.pullrefresh
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.animateIntAsState
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.gestures.FlingBehavior
+import androidx.compose.foundation.gestures.ScrollableDefaults
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.team.designsystem.theme.FlipAppTheme
+import com.team.presentation.util.pullrefresh.pullRefresh
+import com.team.presentation.util.pullrefresh.rememberPullRefreshState
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlin.math.roundToInt
+
+@Composable
+fun FlipPullRefreshLazyColumn(
+    modifier: Modifier = Modifier,
+    state: LazyListState = rememberLazyListState(),
+    contentPadding: PaddingValues = PaddingValues(0.dp),
+    reverseLayout: Boolean = false,
+    verticalArrangement: Arrangement.Vertical =
+        if (!reverseLayout) Arrangement.Top else Arrangement.Bottom,
+    horizontalAlignment: Alignment.Horizontal = Alignment.Start,
+    flingBehavior: FlingBehavior = ScrollableDefaults.flingBehavior(),
+    userScrollEnabled: Boolean = true,
+    content: LazyListScope.() -> Unit,
+) {
+
+    val density = LocalDensity.current
+    val strokeWidthPx = with(density) { strokeWidthDp.toPx() }
+    val iconSizePx = with(density) { iconSizeDp.toPx() }
+
+    var isRefreshing by remember { mutableStateOf(false) }
+    val coroutineScope = rememberCoroutineScope()
+
+    val pullRefreshState = rememberPullRefreshState(
+        refreshing = isRefreshing,
+        refreshThreshold = 50.dp,
+        onRefresh = {
+            coroutineScope.launch {
+                isRefreshing = true
+                // Mimic refresh
+                delay(2000)
+                isRefreshing = false
+            }
+        })
+
+    // 드래그 하는 동안 오프셋 Y의 위치 애니메이션화
+    val offsetYAnimation by animateIntAsState(targetValue = when {
+        isRefreshing -> offsetDelta
+        pullRefreshState.progress in 0f..1f -> (offsetDelta * pullRefreshState.progress).roundToInt()
+        pullRefreshState.progress > 1f -> (offsetDelta + ((pullRefreshState.progress - 1f) * .1f) * 100).roundToInt()
+        else -> 0
+    }, label = "OffsetYAnimation")
+
+    // 드래그 하는 동안 알파 값 애니메이션화
+    val alphaAnimation by animateFloatAsState(targetValue = when {
+        isRefreshing -> 0.3f
+        (1 - pullRefreshState.progress * 10) > 0.3f -> 1 - pullRefreshState.progress * 10
+        (1 - pullRefreshState.progress * 10) < 0.3f -> 0.3f
+        else -> 1f
+    }, label = "AlphaAnimation")
+
+    // 드래그 하는 동안 스케일 값 애니메이션
+    val scaleAnimation by animateFloatAsState(targetValue = when {
+        isRefreshing -> 1.2f
+        pullRefreshState.progress + 1 > 1.2f -> 1.2f
+        pullRefreshState.progress + 1 < 1.2f -> pullRefreshState.progress + 1
+        else -> 1f
+    }, label = "ScaleAnimation")
+
+    // Pull 완료 상태 (return true or false)
+    val pullCompleted by remember {
+        derivedStateOf {
+            pullRefreshState.progress >= 1f
+        }
+    }
+
+    // Pull 완료 상태에 대한 스케일 값 애니메이션화
+    val scaleAnimationOnPullCompleted = remember {
+        Animatable(initialValue = 1f)
+    }
+    // 햅틱 피드백
+    val hapticFeedback = LocalHapticFeedback.current
+    LaunchedEffect(pullCompleted) {
+        if (pullCompleted) {
+            // Pull 완료 시 요소 바운싱 효과
+            scaleAnimationOnPullCompleted.animateTo(1.17f)
+            scaleAnimationOnPullCompleted.animateTo(1f)
+
+            hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
+        }
+    }
+
+    // 새로고침 중 움직일 경로 애니메이션화
+    val pathBackOnRefreshing = remember {
+        Animatable(initialValue = 0f)
+    }
+    LaunchedEffect(isRefreshing) {
+        if (isRefreshing) {
+            pathBackOnRefreshing.animateTo(
+                targetValue = 360f,
+                animationSpec = infiniteRepeatable(tween(1000), repeatMode = RepeatMode.Reverse)
+            )
+        } else {
+            pathBackOnRefreshing.snapTo(0f)
+        }
+    }
+
+    // Pull Progress 값 애니메이션화
+    val pullProgressAnimation by animateFloatAsState(
+        targetValue = pullRefreshState.progress,
+        animationSpec = spring(stiffness = Spring.StiffnessMedium),
+        label = "PullProgressAnimation"
+    )
+
+    Column(
+        modifier = Modifier.pullRefresh(pullRefreshState),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Top
+    ) {
+        Box {
+            Canvas(
+                modifier = Modifier
+                    .align(Alignment.TopCenter)
+                    .graphicsLayer {
+                        translationY = offsetYAnimation.dp.toPx() - iconSizePx
+                        scaleX = scaleAnimation
+                        scaleY = scaleAnimation
+                    }
+                    .graphicsLayer {
+                        scaleX = scaleAnimationOnPullCompleted.value
+                        scaleY = scaleAnimationOnPullCompleted.value
+                    },
+                onDraw = {
+                    val convertedValue = pullProgressAnimation * 360
+
+                    if (!pullRefreshState.refreshing) {
+                        drawArc(
+                            brush = SolidColor(strokeColor),
+                            startAngle = 270f,
+                            sweepAngle = convertedValue,
+                            useCenter = false,
+                            style = Stroke(strokeWidthPx, cap = StrokeCap.Round),
+                            size = Size(iconSizePx, iconSizePx),
+                            topLeft = center.copy(x = center.x - iconSizePx / 2)
+                        )
+                    }
+                }
+            )
+
+            // 드래그 완료 시 표시될 부분
+            if (pullRefreshState.refreshing) {
+                CircularProgressIndicator(
+                    modifier = Modifier
+                        .size(iconSizeDp)
+                        .align(Alignment.TopCenter)
+                        .graphicsLayer {
+                            translationY = offsetYAnimation.dp.toPx()
+                            scaleX = scaleAnimation
+                            scaleY = scaleAnimation
+                        }
+                        .graphicsLayer {
+                            scaleX = scaleAnimationOnPullCompleted.value
+                            scaleY = scaleAnimationOnPullCompleted.value
+                        },
+                    color = strokeColor,
+                    strokeWidth = strokeWidthDp,
+                    strokeCap = StrokeCap.Round
+                )
+            }
+        }
+
+        LazyColumn(
+            modifier = modifier
+                .graphicsLayer {
+                    translationY = offsetYAnimation.dp.toPx()
+                },
+            state = state,
+            contentPadding = contentPadding,
+            reverseLayout = reverseLayout,
+            verticalArrangement = verticalArrangement,
+            horizontalAlignment = horizontalAlignment,
+            flingBehavior = flingBehavior,
+            userScrollEnabled = userScrollEnabled
+        ) {
+            content()
+        }
+    }
+}
+
+private val strokeWidthDp = 2.dp
+private val strokeColor = Color(0xFF3B82F6)
+private val iconSizeDp = 30.dp
+/**
+ * 새로 고침 트리거 거리
+ * 새로 고침을 하기 위해 얼마나 많이 화면을 아래로 당겨야 하는 지를 결정
+ */
+private val positionalThresholdDp = 50.dp
+private const val offsetDelta = 50
+
+@Preview(showBackground = true)
+@Composable
+private fun FlipPullRefreshLazyColumn2Preview() {
+
+    val items = remember {
+        List(100) { it }
+    }
+
+    FlipAppTheme {
+        FlipPullRefreshLazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+//                .padding(16.dp)
+        ) {
+            items(items) { item ->
+                Text(text = "Item $item")
+            }
+        }
+    }
+}

--- a/presentation/src/main/java/com/team/presentation/home/HomeRoute.kt
+++ b/presentation/src/main/java/com/team/presentation/home/HomeRoute.kt
@@ -7,18 +7,14 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.lifecycle.repeatOnLifecycle
 import com.team.designsystem.theme.FlipTheme
 import com.team.presentation.common.bottomsheet.ReportAndBlockBottomSheet
 import com.team.presentation.common.bottomsheet.ReportAndBlockUiEvent
@@ -41,10 +37,10 @@ fun HomeRoute(
     onSettingClick: () -> Unit,
 ) {
 
-    val categoryState by homeViewModel.categoriesState.collectAsStateWithLifecycle()
     val postState by homeViewModel.postState.collectAsStateWithLifecycle()
     val reportState by homeViewModel.reportState.collectAsStateWithLifecycle()
     val blockState by homeViewModel.blockState.collectAsStateWithLifecycle()
+    val filteredMyCategoriesState by homeViewModel.filteredMyCategoriesState.collectAsStateWithLifecycle()
 
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     var startFromReportView: Boolean? by remember { mutableStateOf(null) }
@@ -53,12 +49,12 @@ fun HomeRoute(
 
     val coroutineScope = rememberCoroutineScope()
 
-    val lifecycleOwner = LocalLifecycleOwner.current
-    LaunchedEffect(lifecycleOwner) {
-        lifecycleOwner.repeatOnLifecycle(Lifecycle.State.CREATED) {
-            homeViewModel.fetchCategories()
-        }
-    }
+//    val lifecycleOwner = LocalLifecycleOwner.current
+//    LaunchedEffect(lifecycleOwner) {
+//        lifecycleOwner.repeatOnLifecycle(Lifecycle.State.CREATED) {
+//            homeViewModel.fetchCategories()
+//        }
+//    }
 
     ReportAndBlockBottomSheet(
         startFromReportView = startFromReportView,
@@ -83,7 +79,7 @@ fun HomeRoute(
             .fillMaxSize()
             .background(FlipTheme.colors.white)
             .padding(bottom = innerPadding.calculateBottomPadding()),
-        categoryState = categoryState,
+        myCategories = filteredMyCategoriesState,
         postState = postState,
         flipCardUiEvent = homeViewModel::onFlipCardEvent,
         homeUiEvent = homeViewModel::onHomeUiEvent,

--- a/presentation/src/main/java/com/team/presentation/home/view/HomeTab.kt
+++ b/presentation/src/main/java/com/team/presentation/home/view/HomeTab.kt
@@ -41,6 +41,10 @@ import kotlinx.coroutines.launch
 
 /**
  * 홈 화면에서 사용되는 카테고리 탭 바
+ *
+ * @param items (카테고리)탭 바에 표시되는 카테고리 리스트
+ * @param itemSplitSize 고정 카테고리와 나의 관심 카테고리를 구분 짓는 구분선 기준
+ * @param onItemClick 카테고리 클릭 시
  */
 @Composable
 fun HomeTab(

--- a/presentation/src/main/java/com/team/presentation/home/view/HomeTopBarWrapper.kt
+++ b/presentation/src/main/java/com/team/presentation/home/view/HomeTopBarWrapper.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.zIndex
  *
  * BoxScope 내에서 사용되어야 한다.
  *
- * @param topBarHeightOffsetPx TopBar(content 부분)의 높이 오프셋 px 값
+ * @param animatedTopBarOffset TopBar(content 부분)의 높이 오프셋 px 값
  * @param content Composable 함수로 TopBar 에 해당 되는 부분
  */
 @Composable

--- a/presentation/src/main/java/com/team/presentation/util/CategoriesResources.kt
+++ b/presentation/src/main/java/com/team/presentation/util/CategoriesResources.kt
@@ -1,6 +1,7 @@
 package com.team.presentation.util
 
 import com.team.domain.model.category.Category
+import com.team.domain.model.category.fixedCategories
 import com.team.presentation.R
 
 /**
@@ -42,3 +43,5 @@ val CategoryIconsMap = mapOf(
     101 to R.drawable.ic_category_following,
     102 to R.drawable.ic_category_popular
 )
+
+val fixedCategoriesSize = fixedCategories.size

--- a/presentation/src/main/java/com/team/presentation/util/pullrefresh/PullRefresh.kt
+++ b/presentation/src/main/java/com/team/presentation/util/pullrefresh/PullRefresh.kt
@@ -1,0 +1,96 @@
+package com.team.presentation.util.pullrefresh
+
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.unit.Velocity
+
+/**
+ * A nested scroll modifier that provides scroll events to [state].
+ *
+ * Note that this modifier must be added above a scrolling container, such as a lazy column, in
+ * order to receive scroll events. For example:
+ *
+ * @sample androidx.compose.material.samples.PullRefreshSample
+ * @param state The [PullRefreshState] associated with this pull-to-refresh component. The state
+ *   will be updated by this modifier.
+ * @param enabled If not enabled, all scroll delta and fling velocity will be ignored.
+ */
+// TODO(b/244423199): Move pullRefresh into its own material library similar to material-ripple.
+fun Modifier.pullRefresh(state: PullRefreshState, enabled: Boolean = true) =
+    pullRefresh(state::onPull, state::onRelease, enabled)
+
+/**
+ * A nested scroll modifier that provides [onPull] and [onRelease] callbacks to aid building custom
+ * pull refresh components.
+ *
+ * Note that this modifier must be added above a scrolling container, such as a lazy column, in
+ * order to receive scroll events. For example:
+ *
+ * @sample androidx.compose.material.samples.CustomPullRefreshSample
+ * @param onPull Callback for dispatching vertical scroll delta, takes float pullDelta as argument.
+ *   Positive delta (pulling down) is dispatched only if the child does not consume it (i.e. pulling
+ *   down despite being at the top of a scrollable component), whereas negative delta (swiping up)
+ *   is dispatched first (in case it is needed to push the indicator back up), and then the
+ *   unconsumed delta is passed on to the child. The callback returns how much delta was consumed.
+ * @param onRelease Callback for when drag is released, takes float flingVelocity as argument. The
+ *   callback returns how much velocity was consumed - in most cases this should only consume
+ *   velocity if pull refresh has been dragged already and the velocity is positive (the fling is
+ *   downwards), as an upwards fling should typically still scroll a scrollable component beneath
+ *   the pullRefresh. This is invoked before any remaining velocity is passed to the child.
+ * @param enabled If not enabled, all scroll delta and fling velocity will be ignored and neither
+ *   [onPull] nor [onRelease] will be invoked.
+ */
+fun Modifier.pullRefresh(
+    onPull: (pullDelta: Float) -> Float,
+    onRelease: suspend (flingVelocity: Float) -> Float,
+    enabled: Boolean = true
+) = nestedScroll(PullRefreshNestedScrollConnection(onPull, onRelease, enabled))
+
+private class PullRefreshNestedScrollConnection(
+    private val onPull: (pullDelta: Float) -> Float,
+    private val onRelease: suspend (flingVelocity: Float) -> Float,
+    private val enabled: Boolean
+) : NestedScrollConnection {
+
+    override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset =
+        when {
+            !enabled -> Offset.Zero
+            source == NestedScrollSource.Drag && available.y < 0 ->
+                Offset(0f, onPull(available.y)) // Swiping up
+            else -> Offset.Zero
+        }
+
+    override fun onPostScroll(
+        consumed: Offset,
+        available: Offset,
+        source: NestedScrollSource
+    ): Offset =
+        when {
+            !enabled -> Offset.Zero
+            source == NestedScrollSource.Drag && available.y > 0 ->
+                Offset(0f, onPull(available.y)) // Pulling down
+            else -> Offset.Zero
+        }
+
+    override suspend fun onPreFling(available: Velocity): Velocity {
+        return Velocity(0f, onRelease(available.y))
+    }
+}

--- a/presentation/src/main/java/com/team/presentation/util/pullrefresh/PullRefreshIndicator.kt
+++ b/presentation/src/main/java/com/team/presentation/util/pullrefresh/PullRefreshIndicator.kt
@@ -1,0 +1,227 @@
+package com.team.presentation.util.pullrefresh
+
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import androidx.compose.animation.Crossfade
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.contentColorFor
+import androidx.compose.material3.surfaceColorAtElevation
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.center
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathFillType
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.rotate
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import kotlin.math.abs
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.pow
+
+/**
+ * The default indicator for Compose pull-to-refresh, based on Android's SwipeRefreshLayout.
+ *
+ * @sample androidx.compose.material.samples.PullRefreshSample
+ * @param refreshing A boolean representing whether a refresh is occurring.
+ * @param state The [PullRefreshState] which controls where and how the indicator will be drawn.
+ * @param modifier Modifiers for the indicator.
+ * @param backgroundColor The color of the indicator's background.
+ * @param contentColor The color of the indicator's arc and arrow.
+ * @param scale A boolean controlling whether the indicator's size scales with pull progress or not.
+ */
+@Composable
+// TODO(b/244423199): Consider whether the state parameter should be replaced with lambdas to
+//  enable people to use this indicator with custom pull-to-refresh components.
+fun PullRefreshIndicator(
+    refreshing: Boolean,
+    state: PullRefreshState,
+    modifier: Modifier = Modifier,
+    backgroundColor: Color = MaterialTheme.colorScheme.surface,
+    contentColor: Color = contentColorFor(backgroundColor),
+    scale: Boolean = false
+) {
+    val showElevation by
+    remember(refreshing, state) { derivedStateOf { refreshing || state.position > 0.5f } }
+
+    // Apply an elevation overlay if needed. Note that we aren't using Surface here, as we do not
+    // want its input-blocking behaviour, since the indicator is typically displayed above other
+    // (possibly) interactive content.
+//    val elevationOverlay = LocalElevationOverlay.current
+//    val color =
+//        elevationOverlay?.apply(color = backgroundColor, elevation = Elevation) ?: backgroundColor
+    val color = MaterialTheme.colorScheme.surfaceColorAtElevation(elevation = Elevation)
+
+    Box(
+        modifier =
+        modifier
+            .size(IndicatorSize)
+            .pullRefreshIndicatorTransform(state, scale)
+            .shadow(if (showElevation) Elevation else 0.dp, SpinnerShape, clip = true)
+            .background(color = color, shape = SpinnerShape)
+    ) {
+        Crossfade(
+            targetState = refreshing,
+            animationSpec = tween(durationMillis = CrossfadeDurationMs), label = ""
+        ) { refreshing ->
+            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                val spinnerSize = (ArcRadius + StrokeWidth).times(2)
+
+                if (refreshing) {
+                    CircularProgressIndicator(
+                        color = contentColor,
+                        strokeWidth = StrokeWidth,
+                        modifier = Modifier.size(spinnerSize),
+                    )
+                } else {
+                    CircularArrowIndicator(state, contentColor, Modifier.size(spinnerSize))
+                }
+            }
+        }
+    }
+}
+
+/** Modifier.size MUST be specified. */
+@Composable
+private fun CircularArrowIndicator(
+    state: PullRefreshState,
+    color: Color,
+    modifier: Modifier,
+) {
+    val path = remember { Path().apply { fillType = PathFillType.EvenOdd } }
+
+    val targetAlpha by
+    remember(state) { derivedStateOf { if (state.progress >= 1f) MaxAlpha else MinAlpha } }
+
+    val alphaState = animateFloatAsState(targetValue = targetAlpha, animationSpec = AlphaTween)
+
+    // Empty semantics for tests
+    Canvas(modifier.semantics {}) {
+        val values = ArrowValues(state.progress)
+        val alpha = alphaState.value
+
+        rotate(degrees = values.rotation) {
+            val arcRadius = ArcRadius.toPx() + StrokeWidth.toPx() / 2f
+            val arcBounds =
+                Rect(
+                    size.center.x - arcRadius,
+                    size.center.y - arcRadius,
+                    size.center.x + arcRadius,
+                    size.center.y + arcRadius
+                )
+            drawArc(
+                color = color,
+                alpha = alpha,
+                startAngle = values.startAngle,
+                sweepAngle = values.endAngle - values.startAngle,
+                useCenter = false,
+                topLeft = arcBounds.topLeft,
+                size = arcBounds.size,
+                style = Stroke(width = StrokeWidth.toPx(), cap = StrokeCap.Square)
+            )
+            drawArrow(path, arcBounds, color, alpha, values)
+        }
+    }
+}
+
+@Immutable
+private class ArrowValues(
+    val rotation: Float,
+    val startAngle: Float,
+    val endAngle: Float,
+    val scale: Float
+)
+
+private fun ArrowValues(progress: Float): ArrowValues {
+    // Discard first 40% of progress. Scale remaining progress to full range between 0 and 100%.
+    val adjustedPercent = max(min(1f, progress) - 0.4f, 0f) * 5 / 3
+    // How far beyond the threshold pull has gone, as a percentage of the threshold.
+    val overshootPercent = abs(progress) - 1.0f
+    // Limit the overshoot to 200%. Linear between 0 and 200.
+    val linearTension = overshootPercent.coerceIn(0f, 2f)
+    // Non-linear tension. Increases with linearTension, but at a decreasing rate.
+    val tensionPercent = linearTension - linearTension.pow(2) / 4
+
+    // Calculations based on SwipeRefreshLayout specification.
+    val endTrim = adjustedPercent * MaxProgressArc
+    val rotation = (-0.25f + 0.4f * adjustedPercent + tensionPercent) * 0.5f
+    val startAngle = rotation * 360
+    val endAngle = (rotation + endTrim) * 360
+    val scale = min(1f, adjustedPercent)
+
+    return ArrowValues(rotation, startAngle, endAngle, scale)
+}
+
+private fun DrawScope.drawArrow(
+    arrow: Path,
+    bounds: Rect,
+    color: Color,
+    alpha: Float,
+    values: ArrowValues
+) {
+    arrow.reset()
+    arrow.moveTo(0f, 0f) // Move to left corner
+    arrow.lineTo(x = ArrowWidth.toPx() * values.scale, y = 0f) // Line to right corner
+
+    // Line to tip of arrow
+    arrow.lineTo(x = ArrowWidth.toPx() * values.scale / 2, y = ArrowHeight.toPx() * values.scale)
+
+    val radius = min(bounds.width, bounds.height) / 2f
+    val inset = ArrowWidth.toPx() * values.scale / 2f
+    arrow.translate(
+        Offset(x = radius + bounds.center.x - inset, y = bounds.center.y + StrokeWidth.toPx() / 2f)
+    )
+    arrow.close()
+    rotate(degrees = values.endAngle) { drawPath(path = arrow, color = color, alpha = alpha) }
+}
+
+private const val CrossfadeDurationMs = 100
+private const val MaxProgressArc = 0.8f
+
+private val IndicatorSize = 40.dp
+private val SpinnerShape = CircleShape
+private val ArcRadius = 7.5.dp
+private val StrokeWidth = 2.5.dp
+private val ArrowWidth = 10.dp
+private val ArrowHeight = 5.dp
+private val Elevation = 6.dp
+
+// Values taken from SwipeRefreshLayout
+private const val MinAlpha = 0.3f
+private const val MaxAlpha = 1f
+private val AlphaTween = tween<Float>(300, easing = LinearEasing)

--- a/presentation/src/main/java/com/team/presentation/util/pullrefresh/PullRefreshIndicatorTransform.kt
+++ b/presentation/src/main/java/com/team/presentation/util/pullrefresh/PullRefreshIndicatorTransform.kt
@@ -1,0 +1,63 @@
+package com.team.presentation.util.pullrefresh
+
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import androidx.compose.animation.core.LinearOutSlowInEasing
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.drawscope.clipRect
+import androidx.compose.ui.graphics.graphicsLayer
+
+/**
+ * A modifier for translating the position and scaling the size of a pull-to-refresh indicator based
+ * on the given [PullRefreshState].
+ *
+ * @sample androidx.compose.material.samples.PullRefreshIndicatorTransformSample
+ * @param state The [PullRefreshState] which determines the position of the indicator.
+ * @param scale A boolean controlling whether the indicator's size scales with pull progress or not.
+ */
+// TODO: Consider whether the state parameter should be replaced with lambdas.
+fun Modifier.pullRefreshIndicatorTransform(
+    state: PullRefreshState,
+    scale: Boolean = false,
+) =
+// Essentially we only want to clip the at the top, so the indicator will not appear when
+// the position is 0. It is preferable to clip the indicator as opposed to the layout that
+// contains the indicator, as this would also end up clipping shadows drawn by items in a
+// list for example - so we leave the clipping to the scrolling container. We use MAX_VALUE
+// for the other dimensions to allow for more room for elevation / arbitrary indicators - we
+    // only ever really want to clip at the top edge.
+    drawWithContent {
+        clipRect(
+            top = 0f,
+            left = -Float.MAX_VALUE,
+            right = Float.MAX_VALUE,
+            bottom = Float.MAX_VALUE
+        ) {
+            this@drawWithContent.drawContent()
+        }
+    }
+        .graphicsLayer {
+            translationY = state.position - size.height
+
+            if (scale && !state.refreshing) {
+                val scaleFraction =
+                    LinearOutSlowInEasing.transform(state.position / state.threshold)
+                        .coerceIn(0f, 1f)
+                scaleX = scaleFraction
+                scaleY = scaleFraction
+            }
+        }

--- a/presentation/src/main/java/com/team/presentation/util/pullrefresh/PullRefreshState.kt
+++ b/presentation/src/main/java/com/team/presentation/util/pullrefresh/PullRefreshState.kt
@@ -1,0 +1,234 @@
+package com.team.presentation.util.pullrefresh
+
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import androidx.compose.animation.core.animate
+import androidx.compose.foundation.MutatorMutex
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.State
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import kotlin.math.abs
+import kotlin.math.pow
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+/**
+ * Creates a [PullRefreshState] that is remembered across compositions.
+ *
+ * Changes to [refreshing] will result in [PullRefreshState] being updated.
+ *
+ * @sample androidx.compose.material.samples.PullRefreshSample
+ * @param refreshing A boolean representing whether a refresh is currently occurring.
+ * @param onRefresh The function to be called to trigger a refresh.
+ * @param refreshThreshold The threshold below which, if a release occurs, [onRefresh] will be
+ *   called.
+ * @param refreshingOffset The offset at which the indicator will be drawn while refreshing. This
+ *   offset corresponds to the position of the bottom of the indicator.
+ */
+@Composable
+fun rememberPullRefreshState(
+    refreshing: Boolean,
+    onRefresh: () -> Unit,
+    refreshThreshold: Dp = PullRefreshDefaults.RefreshThreshold,
+    refreshingOffset: Dp = PullRefreshDefaults.RefreshingOffset,
+): PullRefreshState {
+    require(refreshThreshold > 0.dp) { "The refresh trigger must be greater than zero!" }
+
+    val scope = rememberCoroutineScope()
+    val onRefreshState = rememberUpdatedState(onRefresh)
+    val thresholdPx: Float
+    val refreshingOffsetPx: Float
+
+    with(LocalDensity.current) {
+        thresholdPx = refreshThreshold.toPx()
+        refreshingOffsetPx = refreshingOffset.toPx()
+    }
+
+    val state =
+        remember(scope) { PullRefreshState(scope, onRefreshState, refreshingOffsetPx, thresholdPx) }
+
+    SideEffect {
+        state.setRefreshing(refreshing)
+        state.setThreshold(thresholdPx)
+        state.setRefreshingOffset(refreshingOffsetPx)
+    }
+
+    return state
+}
+
+/**
+ * A state object that can be used in conjunction with [pullRefresh] to add pull-to-refresh
+ * behaviour to a scroll component. Based on Android's SwipeRefreshLayout.
+ *
+ * Provides [progress], a float representing how far the user has pulled as a percentage of the
+ * refreshThreshold. Values of one or less indicate that the user has not yet pulled past the
+ * threshold. Values greater than one indicate how far past the threshold the user has pulled.
+ *
+ * Can be used in conjunction with [pullRefreshIndicatorTransform] to implement Android-like
+ * pull-to-refresh behaviour with a custom indicator.
+ *
+ * Should be created using [rememberPullRefreshState].
+ */
+class PullRefreshState
+internal constructor(
+    private val animationScope: CoroutineScope,
+    private val onRefreshState: State<() -> Unit>,
+    refreshingOffset: Float,
+    threshold: Float
+) {
+    /**
+     * A float representing how far the user has pulled as a percentage of the refreshThreshold.
+     *
+     * If the component has not been pulled at all, progress is zero. If the pull has reached
+     * halfway to the threshold, progress is 0.5f. A value greater than 1 indicates that pull has
+     * gone beyond the refreshThreshold - e.g. a value of 2f indicates that the user has pulled to
+     * two times the refreshThreshold.
+     */
+    val progress
+        get() = adjustedDistancePulled / threshold
+
+    internal val refreshing
+        get() = _refreshing
+
+    internal val position
+        get() = _position
+
+    internal val threshold
+        get() = _threshold
+
+    private val adjustedDistancePulled by derivedStateOf { distancePulled * DragMultiplier }
+
+    private var _refreshing by mutableStateOf(false)
+    private var _position by mutableFloatStateOf(0f)
+    private var distancePulled by mutableFloatStateOf(0f)
+    private var _threshold by mutableFloatStateOf(threshold)
+    private var _refreshingOffset by mutableFloatStateOf(refreshingOffset)
+
+    internal fun onPull(pullDelta: Float): Float {
+        if (_refreshing) return 0f // Already refreshing, do nothing.
+
+        val newOffset = (distancePulled + pullDelta).coerceAtLeast(0f)
+        val dragConsumed = newOffset - distancePulled
+        distancePulled = newOffset
+        _position = calculateIndicatorPosition()
+        return dragConsumed
+    }
+
+    internal fun onRelease(velocity: Float): Float {
+        if (refreshing) return 0f // Already refreshing, do nothing
+
+        if (adjustedDistancePulled > threshold) {
+            onRefreshState.value()
+        }
+        animateIndicatorTo(0f)
+        val consumed =
+            when {
+                // We are flinging without having dragged the pull refresh (for example a fling
+                // inside
+                // a list) - don't consume
+                distancePulled == 0f -> 0f
+                // If the velocity is negative, the fling is upwards, and we don't want to prevent
+                // the
+                // the list from scrolling
+                velocity < 0f -> 0f
+                // We are showing the indicator, and the fling is downwards - consume everything
+                else -> velocity
+            }
+        distancePulled = 0f
+        return consumed
+    }
+
+    internal fun setRefreshing(refreshing: Boolean) {
+        if (_refreshing != refreshing) {
+            _refreshing = refreshing
+            distancePulled = 0f
+            animateIndicatorTo(if (refreshing) _refreshingOffset else 0f)
+        }
+    }
+
+    internal fun setThreshold(threshold: Float) {
+        _threshold = threshold
+    }
+
+    internal fun setRefreshingOffset(refreshingOffset: Float) {
+        if (_refreshingOffset != refreshingOffset) {
+            _refreshingOffset = refreshingOffset
+            if (refreshing) animateIndicatorTo(refreshingOffset)
+        }
+    }
+
+    // Make sure to cancel any existing animations when we launch a new one. We use this instead of
+    // Animatable as calling snapTo() on every drag delta has a one frame delay, and some extra
+    // overhead of running through the animation pipeline instead of directly mutating the state.
+    private val mutatorMutex = MutatorMutex()
+
+    private fun animateIndicatorTo(offset: Float) =
+        animationScope.launch {
+            mutatorMutex.mutate {
+                animate(initialValue = _position, targetValue = offset) { value, _ ->
+                    _position = value
+                }
+            }
+        }
+
+    private fun calculateIndicatorPosition(): Float =
+        when {
+            // If drag hasn't gone past the threshold, the position is the adjustedDistancePulled.
+            adjustedDistancePulled <= threshold -> adjustedDistancePulled
+            else -> {
+                // How far beyond the threshold pull has gone, as a percentage of the threshold.
+                val overshootPercent = abs(progress) - 1.0f
+                // Limit the overshoot to 200%. Linear between 0 and 200.
+                val linearTension = overshootPercent.coerceIn(0f, 2f)
+                // Non-linear tension. Increases with linearTension, but at a decreasing rate.
+                val tensionPercent = linearTension - linearTension.pow(2) / 4
+                // The additional offset beyond the threshold.
+                val extraOffset = threshold * tensionPercent
+                threshold + extraOffset
+            }
+        }
+}
+
+/** Default parameter values for [rememberPullRefreshState]. */
+object PullRefreshDefaults {
+    /**
+     * If the indicator is below this threshold offset when it is released, a refresh will be
+     * triggered.
+     */
+    val RefreshThreshold = 80.dp
+
+    /** The offset at which the indicator should be rendered whilst a refresh is occurring. */
+    val RefreshingOffset = 56.dp
+}
+
+/**
+ * The distance pulled is multiplied by this value to give us the adjusted distance pulled, which is
+ * used in calculating the indicator position (when the adjusted distance pulled is less than the
+ * refresh threshold, it is the indicator position, otherwise the indicator position is derived from
+ * the progress).
+ */
+private const val DragMultiplier = 0.5f


### PR DESCRIPTION
### ⚠️  PR check list ⚠️
```
- PR 제목에 JIRA Ticket Number를 적어주세요.
- commit message가 적절한지 확인해주세요. 
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
```

## PR 요약
1. 필터링된 나의 관심 카테고리를 가져오는 UseCase를 추가했기 때문에 이제 UseCase 1개만으로 한 번에 카테고리를 가져올 수 있습니다.
2. PullRefresh 기능을 추가했고 아직 미완성입니다.
(관련해서 추가로 파일 4개를 추가했는데, 이는 Material2 버전용 PullRefresh 복사본입니다.)

### 📝 작업 내용
1. 필터링 된 나의 관심 카테고리 가져오는 UseCase 추가(GetFilteredMyCategoriesUseCase)
2. fixedCategories, Domain 레이어에 포함되게 수정
4. HomeScreen에서 읽는 fixedCategories 개수는 Domain 레이어에서 직접 읽지 않고 CategoriesResources.kt 에서 읽어야 한다.
5. GetMyCategoriesUseCase(), suspend 키워드 제거
6. HomeViewModel 나의 관심 카테고리는 'stateIn' 사용 해서 StateFlow 로 변환
7. PullRefresh 기능 추가 (미완성)

### 💬 리뷰 요구사항
HomeScreen 버벅임이 발생해서 추가 조치 필요
