### PR TITLE
FLIP-136 [refactor] HomeScreen 리팩토링 & PullToRefresh 작업 중 (2차)

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -2,16 +2,10 @@
 <project version="4">
   <component name="deploymentTargetDropDown">
     <value>
-      <entry key="FlipPullRefreshLazyColumn2Preview">
+      <entry key="HomeScreen2Preview">
         <State />
       </entry>
-      <entry key="FlipPullRefreshLazyColumnPreview">
-        <State />
-      </entry>
-      <entry key="PullSample">
-        <State />
-      </entry>
-      <entry key="PullToRefreshAnimationPreview">
+      <entry key="LazyColumnPreview">
         <State />
       </entry>
       <entry key="app">

--- a/designsystem/src/main/java/com/team/designsystem/component/skeleton/HomeSkeletonScreen.kt
+++ b/designsystem/src/main/java/com/team/designsystem/component/skeleton/HomeSkeletonScreen.kt
@@ -10,10 +10,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -37,12 +35,8 @@ fun HomeSkeletonScreen(
     itemCount: Int = 5
 ) {
 
-    val scrollState = rememberScrollState()
-
     Column(
-        modifier = modifier
-            .fillMaxWidth()
-            .verticalScroll(scrollState),
+        modifier = modifier.fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(12.dp, alignment = Alignment.Top)
     ) {

--- a/presentation/src/main/java/com/team/presentation/common/util/BaseViewModel.kt
+++ b/presentation/src/main/java/com/team/presentation/common/util/BaseViewModel.kt
@@ -1,0 +1,8 @@
+package com.team.presentation.common.util
+
+import androidx.lifecycle.ViewModel
+
+open class BaseViewModel: ViewModel() {
+
+
+}

--- a/presentation/src/main/java/com/team/presentation/home/util/HomeScreenNestedScrollConnection.kt
+++ b/presentation/src/main/java/com/team/presentation/home/util/HomeScreenNestedScrollConnection.kt
@@ -1,0 +1,26 @@
+package com.team.presentation.home.util
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.unit.Velocity
+
+class HomeScreenNestedScrollConnection(
+    private val onPreScrollAction: (Offset) -> Unit,
+    private val onPostFlingAction: () -> Unit
+): NestedScrollConnection {
+
+    override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+
+        onPreScrollAction(available)
+
+        return Offset.Zero
+    }
+
+    override suspend fun onPostFling(consumed: Velocity, available: Velocity): Velocity {
+
+        onPostFlingAction()
+
+        return Velocity.Zero
+    }
+}

--- a/presentation/src/main/java/com/team/presentation/home/view/HomeTopBarWrapper.kt
+++ b/presentation/src/main/java/com/team/presentation/home/view/HomeTopBarWrapper.kt
@@ -2,10 +2,11 @@ package com.team.presentation.home.view
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.offset
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.zIndex
 
 /**
@@ -19,17 +20,14 @@ import androidx.compose.ui.zIndex
 @Composable
 fun HomeTopBarWrapper(
     modifier: Modifier = Modifier,
-    animatedTopBarOffset: Float,
+    animatedTopBarOffset: Dp,
     content: @Composable () -> Unit,
 ) {
 
     Column(
         modifier = modifier
             .zIndex(1f)
-            .graphicsLayer(
-                translationX = 0f,
-                translationY = animatedTopBarOffset
-            ),
+            .offset(y = animatedTopBarOffset),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Top
     ) {

--- a/presentation/src/main/java/com/team/presentation/home/viewmodel/HomeViewModel.kt
+++ b/presentation/src/main/java/com/team/presentation/home/viewmodel/HomeViewModel.kt
@@ -7,9 +7,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.team.data.di.DefaultDispatcher
 import com.team.domain.model.category.fixedCategories
-import com.team.domain.usecase.category.GetCategoriesUseCase
 import com.team.domain.usecase.interestcategory.GetFilteredMyCategoriesUseCase
-import com.team.domain.usecase.interestcategory.GetMyCategoriesUseCase
 import com.team.domain.usecase.post.GetPostUseCases
 import com.team.domain.usecase.profile.GetCurrentProfileIdUseCase
 import com.team.domain.util.ErrorType
@@ -27,6 +25,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -36,8 +35,6 @@ import javax.inject.Inject
 class HomeViewModel @Inject constructor(
     @DefaultDispatcher private val defaultDispatcher: CoroutineDispatcher,
     private val getPostUseCases: GetPostUseCases,
-    private val getMyCategoriesUseCase: GetMyCategoriesUseCase,
-    private val getCategoriesUseCase: GetCategoriesUseCase,
     private val getCurrentProfileIdUseCase: GetCurrentProfileIdUseCase,
     private val getFilteredMyCategoriesUseCase: GetFilteredMyCategoriesUseCase
 ) : ViewModel() {
@@ -50,6 +47,7 @@ class HomeViewModel @Inject constructor(
         )
 
     val filteredMyCategoriesState = getFilteredMyCategoriesUseCase()
+        .flowOn(defaultDispatcher)
         .stateIn(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(5_000),


### PR DESCRIPTION
### ⚠️  PR check list ⚠️
```
- PR 제목에 JIRA Ticket Number를 적어주세요.
- commit message가 적절한지 확인해주세요. 
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
```

## PR 요약
- HomeScreen 및 HomeViewModel 리팩토링
- PullRefreshing 리팩토링하면서 새롭게 파일을 몇 개 추가

### 📝 작업 내용
1. 타입 통일(px, dp 중 dp로 통일)을 위해 HomeTopBarWrapper에서 animatedTopBarOffset의 타입 Dp로 수정
2. HomeViewModel에서 filteredMyCategoriesState를 defaultDispatcher에서 실행되게끔 수정
3. HomeScreen에서 TopBar Scroll 관련 로직 리팩토링
4. HomeScreenNestedScrollConnection 추가 (단지, 캡슐화 때문에)
5. HomeSkeletonScreen 스크롤 제거
6. FlipPullRefreshLazyColumn.kt 추가

### 💬 리뷰 요구사항
- HomeScreen 리팩토링 후 새롭게 파일 생성해서 추가
- FlipPullRefreshLazyColumn도 리팩토링 후 새롭게 추가

